### PR TITLE
Silence error about old-style php comments (#)

### DIFF
--- a/templates/ini_file.erb
+++ b/templates/ini_file.erb
@@ -1,7 +1,7 @@
 // File Managed by Puppet
-xdebug.default_enable=<%= default_enable %>
-xdebug.remote_enable=<%= remote_enable %>
-xdebug.remote_handler=<%= remote_handler %>
-xdebug.remote_host=<%= remote_host %>
-xdebug.remote_port=<%= remote_port %>
-xdebug.remote_autostart=<%= remote_autostart %>
+xdebug.default_enable=<%= @default_enable %>
+xdebug.remote_enable=<%= @remote_enable %>
+xdebug.remote_handler=<%= @remote_handler %>
+xdebug.remote_host=<%= @remote_host %>
+xdebug.remote_port=<%= @remote_port %>
+xdebug.remote_autostart=<%= @remote_autostart %>

--- a/templates/ini_file.erb
+++ b/templates/ini_file.erb
@@ -1,4 +1,4 @@
-# File Managed by Puppet
+// File Managed by Puppet
 xdebug.default_enable=<%= default_enable %>
 xdebug.remote_enable=<%= remote_enable %>
 xdebug.remote_handler=<%= remote_handler %>


### PR DESCRIPTION
Newer PHP versions will warn the following:
`PHP Deprecated:  Comments starting with '#' are deprecated in /etc/php5/cli/conf.d/xdebug_config.ini on line 1 in Unknown on line 0`
